### PR TITLE
Make rake validation:generate task available if auto_generate is false

### DIFF
--- a/lib/pretty_validation/renderer.rb
+++ b/lib/pretty_validation/renderer.rb
@@ -24,7 +24,7 @@ module PrettyValidation
     end
 
     def self.generate?(dry_run)
-      PrettyValidation.config.auto_generate && !dry_run
+      !dry_run
     end
 
     def initialize(table_name)

--- a/lib/pretty_validation/schema.rb
+++ b/lib/pretty_validation/schema.rb
@@ -1,7 +1,8 @@
 module PrettyValidation
   class Schema
     def self.table_names
-      ActiveRecord::Base.connection.tables
+      ActiveRecord::Base
+        .connection.tables
         .delete_if { |t| t == ActiveRecord::SchemaMigration.table_name }
     end
 

--- a/lib/pretty_validation/tasks/validation.rake
+++ b/lib/pretty_validation/tasks/validation.rake
@@ -17,7 +17,9 @@ namespace :db do
     # migrate:redo task, which calls other two internally that depend on this one.
     original_db_dump.reenable
 
-    require 'pretty_validation/renderer'
-    PrettyValidation::Renderer.generate
+    if PrettyValidation.config.auto_generate
+      require 'pretty_validation/renderer'
+      PrettyValidation::Renderer.generate
+    end
   end
 end

--- a/lib/pretty_validation/version.rb
+++ b/lib/pretty_validation/version.rb
@@ -1,3 +1,3 @@
 module PrettyValidation
-  VERSION = '0.3.0'
+  VERSION = '0.3.0'.freeze
 end


### PR DESCRIPTION
Now `rake validation:generate` skips like `DRY_RUN` if `auto_generate` is false.
But I want it work normally in the situation, so I modified `db:_dump` and `PrettyValidation::Renderer`.
