### PR TITLE
Add :allow_nil options for nullable integer column

### DIFF
--- a/lib/pretty_validation/validation.rb
+++ b/lib/pretty_validation/validation.rb
@@ -14,6 +14,7 @@ module PrettyValidation
         options = {}
         options[:presence] = true unless column.null
         options[:numericality] = true if column.type == :integer
+        options[:allow_nil] = true if column.null && (column.type == :integer)
 
         Validation.new('validates', column.name.to_sym, options) if options.present?
       end.compact

--- a/spec/pretty_validation/renderer_spec.rb
+++ b/spec/pretty_validation/renderer_spec.rb
@@ -5,6 +5,7 @@ module PrettyValidation
     describe '#render' do
       include_context 'add_column', :name, :string, null: false, default: ''
       include_context 'add_column', :age, :integer
+      include_context 'add_column', :login_count, :integer, null: false, default: 0
       include_context 'add_column', :admin, :boolean
       include_context 'add_index', :name, unique: true
       include_context 'add_index', [:name, :age], unique: true
@@ -17,7 +18,8 @@ module UserValidation
 
   included do
     validates :name, presence: true
-    validates :age, numericality: true
+    validates :age, numericality: true, allow_nil: true
+    validates :login_count, presence: true, numericality: true
     validates_uniqueness_of :name
     validates_uniqueness_of :name, scope: :age
     validates_uniqueness_of :name, scope: [:age, :admin]

--- a/spec/pretty_validation/validation_spec.rb
+++ b/spec/pretty_validation/validation_spec.rb
@@ -9,10 +9,16 @@ module PrettyValidation
         it { is_expected.to include build('validates', :name, presence: true) }
       end
 
-      context 'column type is integer' do
+      context 'column type is nullable integer' do
         include_context 'add_column', :age, :integer
         subject { Validation.sexy_validations('users') }
-        it { is_expected.to include build('validates', :age, numericality: true) }
+        it { is_expected.to include build('validates', :age, numericality: true, allow_nil: true) }
+      end
+
+      context 'column type is not null integer' do
+        include_context 'add_column', :login_count, :integer, null: false, default: 0
+        subject { Validation.sexy_validations('users') }
+        it { is_expected.to include build('validates', :login_count, presence: true, numericality: true) }
       end
     end
 


### PR DESCRIPTION
The validations for nullable integer column make error for null value currently. So I added allow_nil: true option to them.
