### PR TITLE
Fix auto_injection

### DIFF
--- a/lib/pretty_validation/config.rb
+++ b/lib/pretty_validation/config.rb
@@ -10,7 +10,7 @@ module PrettyValidation
   class Configuration
     include ActiveSupport::Configurable
 
-    config_accessor(:auto_generate) { true }
+    config_accessor(:auto_generate) { false }
     config_accessor(:auto_injection) { true }
   end
 end

--- a/lib/pretty_validation/railtie.rb
+++ b/lib/pretty_validation/railtie.rb
@@ -4,7 +4,7 @@ module PrettyValidation
       load 'pretty_validation/tasks/validation.rake'
     end
 
-    initializer 'pretty_validation' do
+    config.to_prepare do
       if PrettyValidation.config.auto_injection
         ActiveSupport.on_load :active_record do
           require 'pretty_validation/validation_findable'

--- a/lib/pretty_validation/renderer.rb
+++ b/lib/pretty_validation/renderer.rb
@@ -24,7 +24,7 @@ module PrettyValidation
     end
 
     def self.generate?(dry_run)
-      PrettyValidation.config.auto_generate && !dry_run
+      !dry_run
     end
 
     def initialize(table_name)

--- a/lib/pretty_validation/schema.rb
+++ b/lib/pretty_validation/schema.rb
@@ -1,7 +1,8 @@
 module PrettyValidation
   class Schema
     def self.table_names
-      ActiveRecord::Base.connection.tables
+      ActiveRecord::Base
+        .connection.tables
         .delete_if { |t| t == ActiveRecord::SchemaMigration.table_name }
     end
 

--- a/lib/pretty_validation/tasks/validation.rake
+++ b/lib/pretty_validation/tasks/validation.rake
@@ -17,7 +17,9 @@ namespace :db do
     # migrate:redo task, which calls other two internally that depend on this one.
     original_db_dump.reenable
 
-    require 'pretty_validation/renderer'
-    PrettyValidation::Renderer.generate
+    if PrettyValidation.config.auto_generate
+      require 'pretty_validation/renderer'
+      PrettyValidation::Renderer.generate
+    end
   end
 end

--- a/lib/pretty_validation/validation.rb
+++ b/lib/pretty_validation/validation.rb
@@ -13,9 +13,13 @@ module PrettyValidation
       columns.map do |column|
         options = {}
         options[:presence] = true unless column.null
-        options[:numericality] = true if column.type == :integer
-        options[:allow_nil] = true if column.null && (column.type == :integer)
-
+        case column.type
+        when :integer
+          options[:numericality] = true
+          options[:allow_nil] = true if column.null
+        when :boolean
+          options[:commented] = true unless options.empty?
+        end
         Validation.new('validates', column.name.to_sym, options) if options.present?
       end.compact
     end
@@ -52,11 +56,11 @@ module PrettyValidation
     end
 
     def to_s
-      if options.blank?
-        "#{method_name} #{column_name.inspect}"
-      else
-        "#{method_name} #{column_name.inspect}, #{options.to_s}"
-      end
+      commented = options ? options.delete(:commented) : false
+      r = "#{method_name} #{column_name.inspect}"
+      r << ", #{options.to_s}" unless options.blank?
+      r = "# #{r}" if commented
+      return r
     end
   end
 end

--- a/lib/pretty_validation/validation.rb
+++ b/lib/pretty_validation/validation.rb
@@ -31,7 +31,7 @@ module PrettyValidation
                   end
 
         columns = Schema.columns(table_name)
-        if x.columns.all?{|colname| col = columns.detect{|c| c.name == colname}; col.null }
+        if x.columns.any?{|colname| col = columns.detect{|c| c.name == colname}; col.null }
           options ||= {}
           options[:allow_nil] = true
         end

--- a/lib/pretty_validation/validation.rb
+++ b/lib/pretty_validation/validation.rb
@@ -14,6 +14,7 @@ module PrettyValidation
         options = {}
         options[:presence] = true unless column.null
         options[:numericality] = true if column.type == :integer
+        options[:allow_nil] = true if column.null && (column.type == :integer)
 
         Validation.new('validates', column.name.to_sym, options) if options.present?
       end.compact

--- a/lib/pretty_validation/validation.rb
+++ b/lib/pretty_validation/validation.rb
@@ -30,6 +30,11 @@ module PrettyValidation
                     { scope: scope[0] }
                   end
 
+        columns = Schema.columns(table_name)
+        if x.columns.all?{|colname| col = columns.detect{|c| c.name == colname}; col.null }
+          options ||= {}
+          options[:allow_nil] = true
+        end
         Validation.new('validates_uniqueness_of', column_name.to_sym, options)
       end
     end

--- a/lib/pretty_validation/version.rb
+++ b/lib/pretty_validation/version.rb
@@ -1,3 +1,3 @@
 module PrettyValidation
-  VERSION = '0.3.0'
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/pretty_validation/renderer_spec.rb
+++ b/spec/pretty_validation/renderer_spec.rb
@@ -22,8 +22,8 @@ module UserValidation
     validates :age, numericality: true, allow_nil: true
     validates :login_count, numericality: true, allow_nil: true
     validates_uniqueness_of :name
-    validates_uniqueness_of :name, scope: :age
-    validates_uniqueness_of :name, scope: [:age, :admin]
+    validates_uniqueness_of :name, scope: :age, allow_nil: true
+    validates_uniqueness_of :name, scope: [:age, :admin], allow_nil: true
     validates_uniqueness_of :login_count, allow_nil: true
   end
 end

--- a/spec/pretty_validation/renderer_spec.rb
+++ b/spec/pretty_validation/renderer_spec.rb
@@ -5,7 +5,7 @@ module PrettyValidation
     describe '#render' do
       include_context 'add_column', :name, :string, null: false, default: ''
       include_context 'add_column', :age, :integer
-      include_context 'add_column', :login_count, :integer, null: false, default: 0
+      include_context 'add_column', :login_count, :integer, null: true, default: 0
       include_context 'add_column', :admin, :boolean
       include_context 'add_index', :name, unique: true
       include_context 'add_index', [:name, :age], unique: true
@@ -19,7 +19,7 @@ module UserValidation
   included do
     validates :name, presence: true
     validates :age, numericality: true, allow_nil: true
-    validates :login_count, presence: true, numericality: true
+    validates :login_count, numericality: true, allow_nil: true
     validates_uniqueness_of :name
     validates_uniqueness_of :name, scope: :age
     validates_uniqueness_of :name, scope: [:age, :admin]

--- a/spec/pretty_validation/renderer_spec.rb
+++ b/spec/pretty_validation/renderer_spec.rb
@@ -7,6 +7,7 @@ module PrettyValidation
       include_context 'add_column', :age, :integer
       include_context 'add_column', :login_count, :integer, null: true, default: 0
       include_context 'add_column', :admin, :boolean
+      include_context 'add_column', :marked, :boolean, null: false, default: false
       include_context 'add_index', :name, unique: true
       include_context 'add_index', [:name, :age], unique: true
       include_context 'add_index', [:name, :age, :admin], unique: true
@@ -21,6 +22,7 @@ module UserValidation
     validates :name, presence: true
     validates :age, numericality: true, allow_nil: true
     validates :login_count, numericality: true, allow_nil: true
+    # validates :marked, presence: true
     validates_uniqueness_of :name
     validates_uniqueness_of :name, scope: :age, allow_nil: true
     validates_uniqueness_of :name, scope: [:age, :admin], allow_nil: true

--- a/spec/pretty_validation/renderer_spec.rb
+++ b/spec/pretty_validation/renderer_spec.rb
@@ -10,6 +10,7 @@ module PrettyValidation
       include_context 'add_index', :name, unique: true
       include_context 'add_index', [:name, :age], unique: true
       include_context 'add_index', [:name, :age, :admin], unique: true
+      include_context 'add_index', :login_count, unique: true
       subject { Renderer.new('users').render }
       it do
         expected = <<-EOF
@@ -23,6 +24,7 @@ module UserValidation
     validates_uniqueness_of :name
     validates_uniqueness_of :name, scope: :age
     validates_uniqueness_of :name, scope: [:age, :admin]
+    validates_uniqueness_of :login_count, allow_nil: true
   end
 end
         EOF

--- a/spec/pretty_validation/renderer_spec.rb
+++ b/spec/pretty_validation/renderer_spec.rb
@@ -5,6 +5,7 @@ module PrettyValidation
     describe '#render' do
       include_context 'add_column', :name, :string, null: false, default: ''
       include_context 'add_column', :age, :integer
+      include_context 'add_column', :login_count, :integer, null: false, default: 0
       include_context 'add_column', :admin, :boolean
       include_context 'add_index', :name, unique: true
       include_context 'add_index', [:name, :age], unique: true
@@ -17,7 +18,8 @@ module UserValidation
 
   included do
     validates :name, presence: true
-    validates :age, numericality: true
+    validates :age, numericality: true, allow_nil: true
+    validates :login_count, presence: true, numericality: true
     validates_uniqueness_of :name
     validates_uniqueness_of :name, scope: :age
     validates_uniqueness_of :name, scope: [:age, :admin]

--- a/spec/pretty_validation/validation_spec.rb
+++ b/spec/pretty_validation/validation_spec.rb
@@ -32,8 +32,8 @@ module PrettyValidation
       subject { Validation.unique_validations('users') }
 
       it { is_expected.to include build('validates_uniqueness_of', :name) }
-      it { is_expected.to include build('validates_uniqueness_of', :name, scope: :age) }
-      it { is_expected.to include build('validates_uniqueness_of', :name, scope: [:age, :admin]) }
+      it { is_expected.to include build('validates_uniqueness_of', :name, scope: :age, allow_nil: true) }
+      it { is_expected.to include build('validates_uniqueness_of', :name, scope: [:age, :admin], allow_nil: true) }
     end
 
     describe '#to_s' do

--- a/spec/pretty_validation/validation_spec.rb
+++ b/spec/pretty_validation/validation_spec.rb
@@ -9,10 +9,16 @@ module PrettyValidation
         it { is_expected.to include build('validates', :name, presence: true) }
       end
 
-      context 'column type is integer' do
+      context 'column type is nullable integer' do
         include_context 'add_column', :age, :integer
         subject { Validation.sexy_validations('users') }
-        it { is_expected.to include build('validates', :age, numericality: true) }
+        it { is_expected.to include build('validates', :age, numericality: true, allow_nil: true) }
+      end
+
+      context 'column type is not null integer' do
+        include_context 'add_column', :login_count, :integer, null: false, default: 0
+        subject { Validation.sexy_validations('users') }
+        it { is_expected.to include build('validates', :login_count, presence: true, numericality: true) }
       end
     end
 

--- a/spec/pretty_validation/validation_spec.rb
+++ b/spec/pretty_validation/validation_spec.rb
@@ -16,9 +16,9 @@ module PrettyValidation
       end
 
       context 'column type is not null integer' do
-        include_context 'add_column', :login_count, :integer, null: false, default: 0
+        include_context 'add_column', :login_count, :integer, null: true, default: 0
         subject { Validation.sexy_validations('users') }
-        it { is_expected.to include build('validates', :login_count, presence: true, numericality: true) }
+        it { is_expected.to include build('validates', :login_count, numericality: true, allow_nil: true) }
       end
     end
 


### PR DESCRIPTION
Even if auto_injection is set in application `config/initializers`, `PrettyValidation::ValidationFindable` is included by `ActiveRecord::Base`.
Because the `initializer` block is called before application `config/initializers` is called.

So use `config.to_prepare` instead of  `initializer`.
