### PR TITLE
Use inclusion validator for boolean field

### DIFF
--- a/lib/pretty_validation/validation.rb
+++ b/lib/pretty_validation/validation.rb
@@ -13,8 +13,14 @@ module PrettyValidation
       columns.map do |column|
         options = {}
         options[:presence] = true unless column.null
-        options[:numericality] = true if column.type == :integer
-        options[:allow_nil] = true if column.null && (column.type == :integer)
+
+        case column.type
+        when :integer
+          options[:numericality] = true
+          options[:allow_nil] = true if column.null
+        when :boolean
+          options[:inclusion] = [true, false]
+        end
 
         Validation.new('validates', column.name.to_sym, options) if options.present?
       end.compact

--- a/lib/pretty_validation/validation.rb
+++ b/lib/pretty_validation/validation.rb
@@ -19,7 +19,9 @@ module PrettyValidation
           options[:numericality] = true
           options[:allow_nil] = true if column.null
         when :boolean
+          options.delete(:presence)
           options[:inclusion] = [true, false]
+          options[:allow_nil] = true if column.null
         end
 
         Validation.new('validates', column.name.to_sym, options) if options.present?

--- a/spec/pretty_validation/renderer_spec.rb
+++ b/spec/pretty_validation/renderer_spec.rb
@@ -7,6 +7,7 @@ module PrettyValidation
       include_context 'add_column', :age, :integer
       include_context 'add_column', :login_count, :integer, null: false, default: 0
       include_context 'add_column', :admin, :boolean
+      include_context 'add_column', :writable, :boolean, null: false, default: true
       include_context 'add_index', :name, unique: true
       include_context 'add_index', [:name, :age], unique: true
       include_context 'add_index', [:name, :age, :admin], unique: true
@@ -20,7 +21,8 @@ module UserValidation
     validates :name, presence: true
     validates :age, numericality: true, allow_nil: true
     validates :login_count, presence: true, numericality: true
-    validates :admin, inclusion: [true, false]
+    validates :admin, inclusion: [true, false], allow_nil: true
+    validates :writable, inclusion: [true, false]
     validates_uniqueness_of :name
     validates_uniqueness_of :name, scope: :age
     validates_uniqueness_of :name, scope: [:age, :admin]

--- a/spec/pretty_validation/renderer_spec.rb
+++ b/spec/pretty_validation/renderer_spec.rb
@@ -20,6 +20,7 @@ module UserValidation
     validates :name, presence: true
     validates :age, numericality: true, allow_nil: true
     validates :login_count, presence: true, numericality: true
+    validates :admin, inclusion: [true, false]
     validates_uniqueness_of :name
     validates_uniqueness_of :name, scope: :age
     validates_uniqueness_of :name, scope: [:age, :admin]


### PR DESCRIPTION
On master branch, if a model which has a boolean field is given `false` value, its validation goes failure.
So fix to use :inclusion according to RailsGuides http://guides.rubyonrails.org/active_record_validations.html#presence .
And remove `:presence` from options for boolean field.
