### PR TITLE
Add ignored_columns to skip generating validation

### DIFF
--- a/lib/pretty_validation/config.rb
+++ b/lib/pretty_validation/config.rb
@@ -12,5 +12,6 @@ module PrettyValidation
 
     config_accessor(:auto_generate) { true }
     config_accessor(:auto_injection) { true }
+    config_accessor(:ignored_columns) { [] }
   end
 end

--- a/lib/pretty_validation/validation.rb
+++ b/lib/pretty_validation/validation.rb
@@ -11,6 +11,7 @@ module PrettyValidation
       columns = columns.reject { |x| x.name.in? %w(id created_at updated_at) }
 
       columns.map do |column|
+        next if PrettyValidation.config.ignored_columns.include?("#{table_name}.#{column.name}")
         options = {}
         options[:presence] = true unless column.null
         options[:numericality] = true if column.type == :integer

--- a/spec/pretty_validation/validation_spec.rb
+++ b/spec/pretty_validation/validation_spec.rb
@@ -19,6 +19,11 @@ module PrettyValidation
         include_context 'add_column', :login_count, :integer, null: false, default: 0
         subject { Validation.sexy_validations('users') }
         it { is_expected.to include build('validates', :login_count, presence: true, numericality: true) }
+
+        context 'column is ignored' do
+          before{ allow(PrettyValidation.config).to receive(:ignored_columns).and_return(['users.login_count']) }
+          it { is_expected.to be_empty }
+        end
       end
     end
 


### PR DESCRIPTION
Skip generating validation with `ignored_columns` if customized validations are needed.

You can set it like this in `config/initializers/pretty_validation.rb`:

``` ruby
PrettyValidation.configure do |config|
  config.ignored_columns = {
    table1: [:foo],
    table2: [:bar, :baz],
  }.map{|t,cols| cols.map{|c| "#{t}.#{c}"} }.flatten
end
```
## Background

When working with [enumerize](https://github.com/brainspec/enumerize), numericality validations for numeric fields reject Symbol values which are allowed by enumerize.
So I need to skip generating validation for some columns.
