### PR TITLE
Add ar_internal_metadata to the filter table for rails5

### DIFF
--- a/lib/pretty_validation/schema.rb
+++ b/lib/pretty_validation/schema.rb
@@ -3,7 +3,7 @@ module PrettyValidation
     def self.table_names
       ActiveRecord::Base
         .connection.tables
-        .delete_if { |t| t == ActiveRecord::SchemaMigration.table_name }
+        .delete_if { |t| t == ActiveRecord::SchemaMigration.table_name || t == 'ar_internal_metadata' }
     end
 
     def self.columns(table_name)


### PR DESCRIPTION
Since ar_internal_metadata is added by default in Rails 5, if you make rake db: migrate, the validation file of ar_internal_metadata will be created.

I think that it works even if it compares with a character string even in Rails 4, so I tried adding a condition, what is it?